### PR TITLE
重构http api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,11 +52,25 @@ GET /api/game/{clientId}/pulse_list
     "pulseList": [
         {
             "id": "pulse-1",
-            "name": "脉冲1"
+            "name": "脉冲1",
+            "pulseData": [ // 可能为null
+                "0A0A0A0A00000000",
+                "0A0A0A0A14141414",
+                "0A0A0A0A28282828",
+                "0A0A0A0A3C3C3C3C",
+                "0A0A0A0A50505050",
+                "0A0A0A0A64646464",
+                "0A0A0A0A64646464",
+                "0A0A0A0A64646464",
+                "0A0A0A0A00000000",
+                "0A0A0A0A00000000",
+                "0A0A0A0A00000000",
+                "0A0A0A0A00000000"
+            ]
         },
         {
             "id": "pulse-2",
-            "name": "脉冲2"
+            "name": "脉冲2",
         }
     ]
 }

--- a/server/src/middlewares/index.ts
+++ b/server/src/middlewares/index.ts
@@ -1,0 +1,122 @@
+import { RouterContext } from "koa-router";
+import { MainConfig } from "../config";
+import { Code, GameApiController, Status } from "../controllers/http/GameApi";
+import { CoyoteLiveGameManager } from "../managers/CoyoteLiveGameManager";
+import { CoyoteLiveGame } from "../controllers/game/CoyoteLiveGame";
+
+export class Middleware {
+    /**
+     * 获取指定的游戏游戏实例，并加入上下文字段 game
+     * 
+     * 若游戏不存在，或广播被禁用，返回错误
+     */
+    public static async acquireGameInstance(ctx: RouterContext, next: Function) {
+        let game: CoyoteLiveGame | null = null;
+        if (ctx.params.id === 'all') {
+            if (!MainConfig.value.allowBroadcastToClients) {
+                GameApiController.setResponse(ctx, {
+                    status: Status.Error,
+                    code: Code.ErrBroadcastNotAllowed,
+                    message: '当前服务器配置不允许向所有客户端广播指令',
+                });
+                return;
+            }
+
+            game = CoyoteLiveGameManager.instance.getGameList().next().value;
+            if (!game) {
+                GameApiController.setResponse(ctx, {
+                    status: Status.Error,
+                    code: Code.ErrGameNotFound,
+                    message: '游戏进程不存在，可能是客户端未连接',
+                });
+                return;
+            }
+        } else {
+            game = Middleware.requestGameInstance(ctx);
+            if (!game) {
+                return;
+            }
+        }
+    
+        ctx.state.game = game;
+    
+        await next();
+    }
+
+    /**
+     * 获取指定的游戏游戏实例，并加入上下文字段 gameList
+     * 
+     * 若游戏不存在，返回空列表
+     * 
+     * 若广播被禁用，返回错误
+     */
+    public static async acquireGameList(ctx: RouterContext, next: Function) {
+        let gameList: Iterable<CoyoteLiveGame> = [];
+        if (ctx.params.id === 'all') {
+            //todo
+            if (!MainConfig.value.allowBroadcastToClients) {
+                GameApiController.setResponse(ctx, {
+                    status: Status.Error,
+                    code: Code.ErrBroadcastNotAllowed,
+                    message: '当前服务器配置不允许向所有客户端广播指令',
+                });
+                return;
+            }
+
+            gameList = CoyoteLiveGameManager.instance.getGameList();
+        } else {
+            const game = Middleware.requestGameInstance(ctx);
+            if (!game) {
+                return;
+            }
+
+            (gameList as CoyoteLiveGame[]).push(game);
+        }
+    
+        ctx.state.gameList = gameList;
+    
+        await next();
+    }
+
+    /**
+     * 判断请求体是否为空
+     * 
+     * 若参数为空，返回错误
+     */
+    public static async assertNotEmptyBody(ctx: RouterContext, next: Function) {
+        if (!ctx.request.body || Object.keys(ctx.request.body).length === 0) {
+            GameApiController.setResponse(ctx, {
+                status: Status.Error,
+                code: Code.ErrInvalidRequest,
+                message: '无效的请求，参数为空',
+            });
+            return;
+        }
+
+        await next();
+    }
+
+    private static requestGameInstance(ctx: RouterContext): CoyoteLiveGame | null {
+        if (!ctx.params.id) {
+            GameApiController.setResponse(ctx, {
+                status: Status.Error,
+                code: Code.ErrInvalidClientId,
+                message: '无效的客户端ID',
+            });
+            return null;
+        }
+
+        const game = CoyoteLiveGameManager.instance.getGame(ctx.params.id);
+        if (!game) {
+            GameApiController.setResponse(ctx, {
+                status: Status.Error,
+                code: Code.ErrGameNotFound,
+                message: '游戏进程不存在，可能是客户端未连接',
+            });
+            return null;
+        }
+
+        return game;
+    }
+}
+

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -4,6 +4,7 @@ import { DGLabWSManager } from './managers/DGLabWSManager';
 import { WebController } from './controllers/http/Web';
 import { WebWSManager } from './managers/WebWSManager';
 import { GameApiController } from './controllers/http/GameApi';
+import { Middleware } from './middlewares';
 
 export const setupRouter = (router: KoaRouter, wsRouter: WebSocketRouter) => {
     router.get('/', WebController.index);
@@ -11,15 +12,30 @@ export const setupRouter = (router: KoaRouter, wsRouter: WebSocketRouter) => {
     router.get('/api/client/connect', WebController.getClientConnectInfo);
 
     router.get('/api/game', GameApiController.gameApiInfo);
-    router.get('/api/game/:id', GameApiController.gameInfo);
-    router.get('/api/game/:id/strength_config', GameApiController.getStrengthConfig);
-    router.post('/api/game/:id/strength_config', GameApiController.setStrengthConfig);
-    router.get('/api/game/:id/pulse_id', GameApiController.getPulseId);
-    router.post('/api/game/:id/pulse_id', GameApiController.setPulseId);
+    router.get('/api/game/:id', Middleware.acquireGameInstance, GameApiController.gameInfo);
+    router.get('/api/game/:id/strength_config',
+        Middleware.acquireGameInstance,
+        GameApiController.getStrengthConfig);
+    router.post('/api/game/:id/strength_config',
+        Middleware.assertNotEmptyBody,
+        Middleware.acquireGameList,
+        GameApiController.setStrengthConfig);
+    router.get('/api/game/:id/pulse_id',
+        Middleware.acquireGameInstance,
+        GameApiController.getPulseId);
+    router.post('/api/game/:id/pulse_id',
+        Middleware.assertNotEmptyBody,
+        Middleware.acquireGameList,
+        GameApiController.setPulseId);
 
-    router.get('/api/game/:id/pulse_list', GameApiController.getPulseList);
+    router.get('/api/game/:id/pulse_list',
+        Middleware.acquireGameInstance,
+        GameApiController.getPulseList);
 
-    router.post('/api/game/:id/fire', GameApiController.fire);
+    router.post('/api/game/:id/fire',
+        Middleware.assertNotEmptyBody,
+        Middleware.acquireGameList,
+        GameApiController.fire);
 
     wsRouter.get('/ws', async (ws, req) => {
         WebWSManager.instance.handleWebSocket(ws, req);


### PR DESCRIPTION
1. 稍微封装，统一接口返回格式
2. 使用中间件抽离参数验证和客户端获取等高频操作
3. 添加响应头字段 app-status 和 app-code ，便于客户端快速判断返回错误类型 来自 https://github.com/hyperzlib/DG-Lab-Coyote-Game-Hub/issues/5 
4. Bug：阻止设置不存在的 pulseId

No.1 No.2 可以不必接受，顺便重构了下，写法仅按照个人习惯，只提供一个思路。
No.4 是重构后测试时顺便发现的。

修改内容较多，劳烦大佬们审查。