### PR TITLE
Fix: implicit any type

### DIFF
--- a/frontend/src/lib/dg-pulse-helper/DGLabPulseQRHelper.ts
+++ b/frontend/src/lib/dg-pulse-helper/DGLabPulseQRHelper.ts
@@ -10,7 +10,7 @@ import { hexToBuffer } from './DGLabPulseHelper';
 
 // Load ZXing WASM module locally
 setZXingModuleOverrides({
-    locateFile: (path, prefix) => {
+    locateFile: (path: string, prefix: string) => {
         if (path.endsWith(".wasm")) {
             return 'lib/' + path;
         }


### PR DESCRIPTION
To make tsc happy.

src/lib/dg-pulse-helper/DGLabPulseQRHelper.ts:13:24 - error TS7006: Parameter 'prefix' implicitly has an 'any' type.

Best Wishes,