### PR TITLE
增加 CORS 支持 & 补充构建文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,27 @@
 
 - ```server```：服务器端代码
 - ```frontend```：前端代码
+
+## 构建
+
+### 环境准备
+在全局环境安装下面的包：
+```
+npm install -g nexe 
+npm install -g vite
+npm install -g pkg
+```
+
+### 构建工程
+按顺序运行下面的指令
+```
+npm run build
+npm run build:pkg
+npm run build:pkg:assets
+npm run build:pkg:nodejs
+npm run build:pkg:linux
+npm run build:pkg
+```
+
+### 产物位置
+之后可以在 `build/` 目录下发现构建的产物

--- a/frontend/src/components/dialogs/ConnectToClientDialog.vue
+++ b/frontend/src/components/dialogs/ConnectToClientDialog.vue
@@ -56,7 +56,7 @@ const wsUrlList = computed(() => {
     }
   });
 });
-
+/* error TS6133: 'handleResetClientId' is declared but its value is never read.
 const handleResetClientId = async () => {
   if (state.clientIdResetting) {
     return;
@@ -67,6 +67,7 @@ const handleResetClientId = async () => {
   state.clientIdResetting = true;
   emit('resetClientId');
 };
+*/
 
 const handleSetClientId = () => {
   emit('update:clientId', state.formClientId);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hyperzlib/node-reactive-config": "^1.1.1",
         "@koa/bodyparser": "^5.1.1",
+        "@koa/cors": "^5.0.0",
         "ajv": "^8.16.0",
         "blocked-at": "^1.2.0",
         "es-get-iterator": "^1.1.3",
@@ -32,6 +33,7 @@
         "@types/blocked-at": "^1.0.4",
         "@types/js-yaml": "^4.0.9",
         "@types/koa": "^2.15.0",
+        "@types/koa__cors": "^5.0.0",
         "@types/koa-router": "^7.4.8",
         "@types/koa-static": "^4.0.4",
         "@types/uuid": "^10.0.0",
@@ -482,6 +484,18 @@
         "koa": "^2.14.1"
       }
     },
+    "node_modules/@koa/cors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
+      "license": "MIT",
+      "dependencies": {
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -681,6 +695,16 @@
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa__cors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-5.0.0.tgz",
+      "integrity": "sha512-LCk/n25Obq5qlernGOK/2LUwa/2YJb2lxHUkkvYFDOpLXlVI6tKcdfCHRBQnOY4LwH6el5WOLs6PD/a8Uzau6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
       }
     },
     "node_modules/@types/koa-compose": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "@types/blocked-at": "^1.0.4",
     "@types/js-yaml": "^4.0.9",
     "@types/koa": "^2.15.0",
+    "@types/koa__cors": "^5.0.0",
     "@types/koa-router": "^7.4.8",
     "@types/koa-static": "^4.0.4",
     "@types/uuid": "^10.0.0",
@@ -37,6 +38,7 @@
   "dependencies": {
     "@hyperzlib/node-reactive-config": "^1.1.1",
     "@koa/bodyparser": "^5.1.1",
+    "@koa/cors": "^5.0.0",
     "ajv": "^8.16.0",
     "blocked-at": "^1.2.0",
     "es-get-iterator": "^1.1.3",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import Koa from 'koa';
 import WebSocket from 'ws';
 import KoaRouter from 'koa-router';
+import cors from '@koa/cors';
 import { WebSocketRouter } from './utils/WebSocketRouter';
 import { setupWebSocketServer } from './utils/websocket';
 import { setupRouter as initRouter } from './router';
@@ -35,6 +36,7 @@ async function main() {
     await CustomSkinService.instance.initialize();
 
     const app = new Koa();
+    app.use(cors());
     const httpServer = http.createServer(app.callback());
 
     // 在HTTP服务器上创建WebSocket服务器


### PR DESCRIPTION
背景：
如果要在其他网页应用上调用的话，会因 `Access-Control-Allow-Origin` 没有妥善配置而被拦截。因此在此增加了 CORS 支持，以便调用。

其他问题：
本地构建出来的报出了
```
workspaces/DG-Lab-Coyote-Game-Hub/build (main) $ ./coyote-game-hub-server
Pulse list updated.
TypeError: Cannot read properties of undefined (reading 'version')
    at MainGameConfigUpdater.addSchema (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/utils/ObjectUpdater.js:18:24)
    at MainGameConfigUpdater.registerSchemas (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/model/config/MainGameConfigUpdater.js:8:14)
    at new ObjectUpdater (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/utils/ObjectUpdater.js:7:14)
    at new MainGameConfigUpdater (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/model/config/MainGameConfigUpdater.js:6:1)
    at <instance_members_initializer> (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/services/CoyoteGameConfigService.js:28:36)
    at new CoyoteGameConfigService (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/services/CoyoteGameConfigService.js:23:1)
    at CoyoteGameConfigService.createInstance (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/services/CoyoteGameConfigService.js:39:30)
    at get instance [as instance] (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/services/CoyoteGameConfigService.js:43:14)
    at main (/snapshot/DG-Lab-Coyote-Game-Hub/server/dist/index.js:34:61)
^CExiting DGLabWSManager instance
```
这样的错误，没法正常运行，可能还需要review、补充一下构建相关的步骤。